### PR TITLE
Use 755 as directory permissions rather than 644

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -159,7 +159,7 @@ func (c *Config) Persist() error {
 		return err
 	}
 
-	err = os.MkdirAll(filepath.Dir(path), 0644)
+	err = os.MkdirAll(filepath.Dir(path), 0755)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes issue where directory is being created with the wrong permissions.