### PR TITLE
docs: remove broken link to non-existent style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ Documentation is hosted at https://render.com/docs/cli.
 
 ## Contributing
 
-To create a new command, use the `cmd/template.go` template file as a starting point. Reference the [CLI Style Guide](docs/STYLE.md) to learn more about command naming, flags, arguments, and help text conventions.
+To create a new command, use the `cmd/template.go` template file as a starting point.


### PR DESCRIPTION
Fix README referencing `docs/STYLE.md`
