### PR TITLE
Allow one-off jobs creation from cronjobs

### DIFF
--- a/pkg/resource/service.go
+++ b/pkg/resource/service.go
@@ -197,7 +197,7 @@ func (rs *Service) ListResources(ctx context.Context, params ResourceParams) ([]
 }
 
 func (rs *Service) GetResource(ctx context.Context, id string) (Resource, error) {
-	if strings.HasPrefix(id, serverResourceIDPrefix) {
+	if strings.HasPrefix(id, serverResourceIDPrefix) || strings.HasPrefix(id, cronjobResourceIDPrefix) {
 		return rs.serviceService.GetService(ctx, id)
 	}
 


### PR DESCRIPTION
## Summary

Allows to create one-off job from a cronjob service whose id always start with `crn`:
```
  > render jobs create crn-xxx --start-command "/bin/foo"
```

A cronjob is a type of service.

## Motivation

Self-explanatory.

## How to verify

Create a service with type: cron.
Use the CLI's jobs create command to verify the one-off job creation does work seamlessly.
