### PR TITLE
cfg: make RepoURL and InstallationInstructionsURL overridable vars

### DIFF
--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -7,7 +7,12 @@ import (
 	"strings"
 )
 
-const (
+// RepoURL and InstallationInstructionsURL are vars (like Version) so that
+// programs embedding the command package — importers running the CLI against
+// a Render-compatible backend — can repoint the update check at their own
+// release channel via -ldflags "-X", instead of directing their users to
+// Render's releases and upgrade docs.
+var (
 	RepoURL                     = "https://api.github.com/repos/render-oss/cli"
 	InstallationInstructionsURL = "https://render.com/docs/cli#1-install-or-upgrade"
 )


### PR DESCRIPTION
## What

Turns `cfg.RepoURL` and `cfg.InstallationInstructionsURL` from consts into vars, exactly like the existing `cfg.Version`. No behavior change for the CLI itself.

## Why

The command package is embedder-friendly by design: `cmd.RootCmd` is exported, and `cfg.Version` is already injectable via `-ldflags "-X"`. Programs that import the command package to run the CLI against a Render-compatible backend can attach their own commands and set their own version — but the update check's target is a const, so both call sites (`printVersionWithUpdateCheck` on the `--version` path and the login view's banner) compare the embedder's build against **render-oss/cli** releases and direct the embedder's users to Render's upgrade docs, which is the wrong channel for their distribution.

With these as vars, an embedder adds two `-X` flags at build time and the update check points at their own releases; building this repo unchanged produces byte-identical behavior.

## Notes

- `go build ./...` passes; `gofmt` clean on the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)