### PR TITLE
feat(jobs): stream one-off job logs and propagate terminal status to CI

### DIFF
--- a/cmd/jobcreate.go
+++ b/cmd/jobcreate.go
@@ -2,41 +2,46 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
 
 	"github.com/render-oss/cli/pkg/client"
 	clientjob "github.com/render-oss/cli/pkg/client/jobs"
+	logclient "github.com/render-oss/cli/pkg/client/logs"
 	"github.com/render-oss/cli/pkg/command"
 	"github.com/render-oss/cli/pkg/dependencies"
+	"github.com/render-oss/cli/pkg/job"
+	"github.com/render-oss/cli/pkg/logs"
+	"github.com/render-oss/cli/pkg/pointers"
 	"github.com/render-oss/cli/pkg/resource"
 	"github.com/render-oss/cli/pkg/text"
 	"github.com/render-oss/cli/pkg/tui/flows"
 	"github.com/render-oss/cli/pkg/tui/views"
 )
 
-var JobCreateCmd = &cobra.Command{
-	Use:   "create [serviceID]",
-	Short: "Create a new job for a service",
-	Args:  cobra.MaximumNArgs(1),
-	Example: `  # Create a job for a service
-  render jobs create srv-abc123 --start-command "bundle exec rake task"
-
-  # Create a job with a specific plan
-  # See https://render.com/docs/one-off-jobs for available job plans
-  render jobs create srv-abc123 --start-command "npm run worker" --plan-id plan-srv-006`,
+type jobCreateCommandConfig struct {
+	pollInterval time.Duration
+	newTicker    func(time.Duration) job.TickSource
 }
 
+var JobCreateCmd = newJobCreateCmd()
+
 var InteractiveJobCreate = func(ctx context.Context, input *views.JobCreateInput, breadcrumb string) tea.Cmd {
+	return interactiveJobCreateWithCommand(ctx, input, breadcrumb, JobCreateCmd)
+}
+
+func interactiveJobCreateWithCommand(ctx context.Context, input *views.JobCreateInput, breadcrumb string, cobraCmd *cobra.Command) tea.Cmd {
 	deps := dependencies.GetFromContext(ctx)
 	return command.AddToStackFunc(
 		ctx,
-		JobCreateCmd,
+		cobraCmd,
 		breadcrumb,
 		input,
-		views.NewJobCreateView(ctx, input, JobCreateCmd, views.CreateJob, func(j *clientjob.Job) tea.Cmd {
+		views.NewJobCreateView(ctx, input, cobraCmd, views.CreateJob, func(j *clientjob.Job) tea.Cmd {
 			return flows.NewLogFlow(deps).LogsFlow(ctx, views.LogInput{
 				ResourceIDs: []string{j.Id},
 				Tail:        true,
@@ -59,7 +64,7 @@ func interactiveJobCreate(cmd *cobra.Command, input *views.JobCreateInput) (tea.
 				},
 			}, func(ctx context.Context, r resource.Resource) tea.Cmd {
 				input.ServiceID = r.ID()
-				return InteractiveJobCreate(ctx, input, resource.BreadcrumbForResource(r))
+				return interactiveJobCreateWithCommand(ctx, input, resource.BreadcrumbForResource(r), cmd)
 			}),
 		), nil
 	}
@@ -69,16 +74,68 @@ func interactiveJobCreate(cmd *cobra.Command, input *views.JobCreateInput) (tea.
 		return nil, err
 	}
 
-	return InteractiveJobCreate(ctx, input, "Create Job for "+resource.BreadcrumbForResource(service)), nil
+	return interactiveJobCreateWithCommand(ctx, input, "Create Job for "+resource.BreadcrumbForResource(service), cmd), nil
 }
 
-func init() {
-	JobCreateCmd.RunE = func(cmd *cobra.Command, args []string) error {
+func newJobCreateCmd(configs ...jobCreateCommandConfig) *cobra.Command {
+	var config jobCreateCommandConfig
+	if len(configs) > 0 {
+		config = configs[0]
+	}
+
+	cmd := &cobra.Command{
+		Use:   "create [serviceID]",
+		Short: "Create a new job for a service",
+		Args:  cobra.MaximumNArgs(1),
+		Example: `  # Create a job and return immediately
+  render jobs create srv-abc123 --start-command "bundle exec rake task"
+
+  # Wait for success in CI; failed or canceled jobs exit nonzero
+  render jobs create srv-abc123 --confirm --wait --start-command "npm test"
+
+  # Tail logs with a bounded wait (--tail implies --wait)
+  render jobs create srv-abc123 --confirm --tail --timeout 20m --start-command "npm run worker"
+
+  # Keep stdout as one JSON document; progress and streamed logs go to stderr
+  render jobs create srv-abc123 --confirm --tail --output json > job.json`,
+	}
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		var input views.JobCreateInput
 
-		err := command.ParseCommand(cmd, args, &input)
+		wait, err := cmd.Flags().GetBool("wait")
+		if err != nil {
+			return err
+		}
+		tail, err := cmd.Flags().GetBool("tail")
+		if err != nil {
+			return err
+		}
+		if tail {
+			wait = true
+		}
+
+		timeout, err := cmd.Flags().GetDuration("timeout")
+		if err != nil {
+			return err
+		}
+		if cmd.Flags().Changed("timeout") && !wait {
+			return errors.New("--timeout requires --wait or --tail")
+		}
+		if wait && timeout <= 0 {
+			return errors.New("--timeout must be positive")
+		}
+		if wait {
+			command.DefaultFormatNonInteractive(cmd)
+		}
+
+		err = command.ParseCommand(cmd, args, &input)
 		if err != nil {
 			return fmt.Errorf("failed to parse input: %w", err)
+		}
+
+		if wait {
+			return nonInteractiveJobCreateAndWait(cmd, input, tail, timeout, config)
 		}
 
 		if nonInteractive, err := command.NonInteractive(cmd, func() (*clientjob.Job, error) {
@@ -95,8 +152,87 @@ func init() {
 		return err
 	}
 
-	JobCreateCmd.Flags().String("start-command", "", "Set the job start command")
-	JobCreateCmd.Flags().String("plan-id", "", "Set the plan ID for the job (Optional)")
-	setFlagPlaceholder(JobCreateCmd.Flags(), "start-command", "COMMAND")
-	setFlagPlaceholder(JobCreateCmd.Flags(), "plan-id", "PLAN_ID")
+	cmd.Flags().String("start-command", "", "Set the job start command")
+	cmd.Flags().String("plan-id", "", "Set the plan ID for the job (Optional)")
+	cmd.Flags().Bool("wait", false, "Wait for the job to finish and exit nonzero if it fails or is canceled")
+	cmd.Flags().Bool("tail", false, "Stream job logs and wait for the job to finish")
+	cmd.Flags().Duration("timeout", job.DefaultTimeout, "Maximum time to wait for the job")
+	setFlagPlaceholder(cmd.Flags(), "start-command", "COMMAND")
+	setFlagPlaceholder(cmd.Flags(), "plan-id", "PLAN_ID")
+	setFlagPlaceholder(cmd.Flags(), "timeout", "DURATION")
+
+	return cmd
+}
+
+func nonInteractiveJobCreateAndWait(cmd *cobra.Command, input views.JobCreateInput, tail bool, timeout time.Duration, config jobCreateCommandConfig) error {
+	deps := dependencies.GetFromContext(cmd.Context())
+	created, err := deps.JobRepo().CreateJob(cmd.Context(), job.CreateJobInput{
+		ServiceID:    input.ServiceID,
+		StartCommand: pointers.ValueOrDefault(input.StartCommand, ""),
+		PlanID:       pointers.ValueOrDefault(input.PlanID, ""),
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = fmt.Fprintf(cmd.ErrOrStderr(), "Waiting for job %s to finish...\n", created.Id)
+	if err != nil {
+		return err
+	}
+
+	pollInterval := config.pollInterval
+	if pollInterval <= 0 {
+		pollInterval = job.DefaultPollInterval
+	}
+	runner := job.Runner{
+		Retrieve: func(ctx context.Context) (*clientjob.Job, error) {
+			return deps.JobRepo().GetJob(ctx, input.ServiceID, created.Id)
+		},
+		PollInterval:         pollInterval,
+		MaxTransientAttempts: job.DefaultTransientAttempts,
+		NewTicker:            config.newTicker,
+		OnRetry: func(message string) {
+			_, _ = fmt.Fprintln(cmd.ErrOrStderr(), message)
+		},
+	}
+
+	if tail {
+		runner.OpenLogs = func(ctx context.Context, startTime *time.Time) (*logs.TailStream, error) {
+			logInput := views.LogInput{ResourceIDs: []string{created.Id}, Tail: true}
+			if startTime != nil {
+				logInput.StartTime = &command.TimeOrRelative{T: startTime}
+			}
+			return deps.LogLoader().LoadLogStream(ctx, logInput)
+		}
+		runner.OnLog = func(entry *logclient.Log) error {
+			out := cmd.OutOrStdout()
+			format := command.GetFormatFromContext(cmd.Context())
+			if format != nil && (*format == command.JSON || *format == command.YAML) {
+				out = cmd.ErrOrStderr()
+			}
+			return writeLog(command.TEXT, out, entry)
+		}
+	}
+
+	finalJob, waitErr := runner.Run(cmd.Context(), created.Id, tail, timeout)
+	if finalJob != nil {
+		_, printErr := command.PrintData(cmd, finalJob, func(result *clientjob.Job) string {
+			status := "unknown"
+			if result.Status != nil {
+				status = string(*result.Status)
+			}
+			return text.FormatStringF("Job %s finished with status %s", result.Id, status)
+		})
+		if printErr != nil {
+			return printErr
+		}
+	}
+	if waitErr != nil {
+		var terminalErr *job.TerminalError
+		if errors.As(waitErr, &terminalErr) {
+			return command.NewExitError(1, waitErr)
+		}
+		return waitErr
+	}
+	return nil
 }

--- a/cmd/jobcreate_test.go
+++ b/cmd/jobcreate_test.go
@@ -1,0 +1,379 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	renderapi "github.com/render-oss/cli/internal/fakes/renderapi"
+	"github.com/render-oss/cli/internal/testids"
+	"github.com/render-oss/cli/pkg/client"
+	clientjob "github.com/render-oss/cli/pkg/client/jobs"
+	logclient "github.com/render-oss/cli/pkg/client/logs"
+	"github.com/render-oss/cli/pkg/command"
+	"github.com/render-oss/cli/pkg/dependencies"
+	"github.com/render-oss/cli/pkg/job"
+	"github.com/render-oss/cli/pkg/pointers"
+)
+
+type jobCommandTicker struct{ ticks chan time.Time }
+
+func newJobCommandTicker(count int) *jobCommandTicker {
+	ticker := &jobCommandTicker{ticks: make(chan time.Time, count)}
+	for range count {
+		ticker.ticks <- time.Time{}
+	}
+	return ticker
+}
+
+func (t *jobCommandTicker) C() <-chan time.Time { return t.ticks }
+func (t *jobCommandTicker) Stop()               {}
+
+func executeJobCreateCommand(t *testing.T, server *renderapi.Server, ctx context.Context, ticks int, args ...string) (CommandResult, error) {
+	t.Helper()
+	return executeJobCreateCommandWithTicker(t, server, ctx, newJobCommandTicker(ticks), args...)
+}
+
+func executeJobCreateCommandWithTicker(t *testing.T, server *renderapi.Server, ctx context.Context, ticker *jobCommandTicker, args ...string) (CommandResult, error) {
+	t.Helper()
+	root, stdout, stderr := prepareJobCreateCommand(t, server, ctx, ticker, args...)
+	err := root.Execute()
+	return CommandResult{Stdout: stdout.String(), Stderr: stderr.String()}, err
+}
+
+func prepareJobCreateCommand(t *testing.T, server *renderapi.Server, ctx context.Context, ticker *jobCommandTicker, args ...string) (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	t.Setenv("RENDER_CLI_CONFIG_PATH", newTestConfigPath(t))
+	t.Setenv("RENDER_API_KEY", "test-api-key")
+	t.Setenv("RENDER_HOST", server.URL())
+	t.Setenv("RENDER_WORKSPACE", testids.WorkspaceID("jobs"))
+
+	c, err := client.NewClientWithResponses(server.URL())
+	require.NoError(t, err)
+	deps := dependencies.New(c)
+	deps.DetectRuntimeSignals = func() (command.RuntimeSignals, error) {
+		return command.RuntimeSignals{StdinTTY: false, StdoutTTY: false, StderrTTY: false}, nil
+	}
+
+	root := newRootCmd()
+	jobs := &cobra.Command{Use: "jobs"}
+	jobs.AddCommand(newJobCreateCmd(jobCreateCommandConfig{
+		pollInterval: time.Hour,
+		newTicker:    func(time.Duration) job.TickSource { return ticker },
+	}))
+	root.AddCommand(jobs)
+	setupRootCmdPersistentRun(root, deps)
+	root.SetContext(ctx)
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	root.SetOut(stdout)
+	root.SetErr(stderr)
+	root.SetArgs(append([]string{"jobs", "create"}, args...))
+	return root, stdout, stderr
+}
+
+func TestJobCreateTailImpliesWaitAndKeepsStructuredStdoutClean(t *testing.T) {
+	server := renderapi.NewServer(t)
+	server.Jobs.QueueStatuses(
+		pointers.From(clientjob.Running),
+		pointers.From(clientjob.Running),
+		pointers.From(clientjob.Succeeded),
+	)
+	now := time.Unix(100, 0).UTC()
+	server.Logs.QueueStream(
+		renderapi.LogStreamAttempt{
+			Logs: []logclient.Log{
+				{Id: "log-1", Message: "first line", Timestamp: now},
+				{Id: "log-2", Message: "second line", Timestamp: now.Add(time.Second)},
+			},
+			CloseCode: websocket.CloseInternalServerErr,
+		},
+		renderapi.LogStreamAttempt{
+			Logs: []logclient.Log{
+				{Id: "log-2", Message: "second line", Timestamp: now.Add(time.Second)},
+				{Id: "log-3", Message: "third line", Timestamp: now.Add(2 * time.Second)},
+			},
+			HoldOpen: true,
+		},
+	)
+	ticker := newJobCommandTicker(0)
+	root, stdout, stderr := prepareJobCreateCommand(t, server, context.Background(), ticker,
+		"srv-jobcreate000000000", "--tail", "--output", "json")
+	outcome := make(chan error, 1)
+	go func() {
+		outcome <- root.Execute()
+	}()
+
+	<-server.Logs.Opened()
+	<-server.Logs.Closed()
+	ticker.ticks <- time.Time{}
+	<-server.Logs.Opened()
+	ticker.ticks <- time.Time{}
+	require.NoError(t, <-outcome)
+	<-server.Logs.Closed()
+
+	var final clientjob.Job
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &final))
+	require.NotNil(t, final.Status)
+	assert.Equal(t, clientjob.Succeeded, *final.Status)
+	assert.NotContains(t, stdout.String(), "first line")
+	assert.Contains(t, stderr.String(), "first line")
+	assert.Contains(t, stderr.String(), "third line")
+	assert.Equal(t, 1, strings.Count(stderr.String(), "second line"))
+	assert.Equal(t, 1, server.Jobs.CreateRequestCount())
+	assert.Equal(t, 3, server.Jobs.RetrieveRequestCount())
+	assert.Equal(t, 2, server.Logs.StreamRequestCount())
+	assert.NotEmpty(t, server.Logs.Query(1).Get("startTime"))
+}
+
+func TestJobCreateTailKeepsYAMLStdoutClean(t *testing.T) {
+	server := renderapi.NewServer(t)
+	server.Jobs.QueueStatuses(
+		pointers.From(clientjob.Running),
+		pointers.From(clientjob.Running),
+		pointers.From(clientjob.Succeeded),
+	)
+	server.Logs.QueueStream(
+		renderapi.LogStreamAttempt{
+			Logs: []logclient.Log{{
+				Id: "log-yaml", Message: "yaml log line", Timestamp: time.Unix(100, 0).UTC(),
+			}},
+			CloseCode: websocket.CloseInternalServerErr,
+		},
+		renderapi.LogStreamAttempt{HoldOpen: true},
+	)
+	ticker := newJobCommandTicker(0)
+	root, stdout, stderr := prepareJobCreateCommand(t, server, context.Background(), ticker,
+		"srv-jobcreate000000000", "--tail", "--output", "yaml")
+	result := make(chan error, 1)
+	go func() { result <- root.Execute() }()
+	<-server.Logs.Opened()
+	<-server.Logs.Closed()
+	ticker.ticks <- time.Time{}
+	<-server.Logs.Opened()
+	ticker.ticks <- time.Time{}
+	require.NoError(t, <-result)
+	<-server.Logs.Closed()
+
+	var final map[string]any
+	require.NoError(t, yaml.Unmarshal(stdout.Bytes(), &final))
+	assert.Equal(t, "succeeded", final["status"])
+	assert.NotContains(t, stdout.String(), "yaml log line")
+	assert.Contains(t, stderr.String(), "yaml log line")
+}
+
+func TestJobCreateTailTextSeparatesLogsFromControlMessages(t *testing.T) {
+	server := renderapi.NewServer(t)
+	server.Jobs.QueueStatuses(
+		pointers.From(clientjob.Running),
+		pointers.From(clientjob.Running),
+		pointers.From(clientjob.Succeeded),
+	)
+	server.Logs.QueueStream(
+		renderapi.LogStreamAttempt{
+			Logs: []logclient.Log{{
+				Id: "log-text", Message: "pipeline output", Timestamp: time.Unix(100, 0).UTC(),
+			}},
+			CloseCode: websocket.CloseInternalServerErr,
+		},
+		renderapi.LogStreamAttempt{HoldOpen: true},
+	)
+	ticker := newJobCommandTicker(0)
+	root, stdout, stderr := prepareJobCreateCommand(t, server, context.Background(), ticker,
+		"srv-jobcreate000000000", "--tail", "--output", "text")
+	result := make(chan error, 1)
+	go func() { result <- root.Execute() }()
+	<-server.Logs.Opened()
+	<-server.Logs.Closed()
+	ticker.ticks <- time.Time{}
+	<-server.Logs.Opened()
+	ticker.ticks <- time.Time{}
+	require.NoError(t, <-result)
+	<-server.Logs.Closed()
+
+	assert.Contains(t, stdout.String(), "pipeline output")
+	assert.Contains(t, stdout.String(), "finished with status succeeded")
+	assert.NotContains(t, stdout.String(), "Waiting for job")
+	assert.Contains(t, stderr.String(), "Waiting for job")
+	assert.NotContains(t, stderr.String(), "pipeline output")
+}
+
+func TestJobCreateNoWaitPreservesImmediateBehavior(t *testing.T) {
+	server := renderapi.NewServer(t)
+	result, err := executeJobCreateCommand(t, server, context.Background(), 0,
+		"srv-jobcreate000000000", "--start-command", "echo immediate", "--output", "text")
+	require.NoError(t, err)
+	assert.Equal(t, "Created job job-fake0000000000000000 for srv-jobcreate000000000\n", result.Stdout)
+	assert.Empty(t, result.Stderr)
+	assert.Equal(t, 1, server.Jobs.CreateRequestCount())
+	assert.Zero(t, server.Jobs.RetrieveRequestCount())
+}
+
+func TestJobCreateWaitReturnsFinalSucceededJob(t *testing.T) {
+	server := renderapi.NewServer(t)
+	server.Jobs.QueueStatuses(
+		pointers.From(clientjob.Pending),
+		pointers.From(clientjob.Running),
+		pointers.From(clientjob.Succeeded),
+	)
+	result, err := executeJobCreateCommand(t, server, context.Background(), 2,
+		"srv-jobcreate000000000", "--wait", "--output", "json")
+	require.NoError(t, err)
+	assert.Zero(t, exitCodeFromError(err))
+	var final clientjob.Job
+	require.NoError(t, json.Unmarshal([]byte(result.Stdout), &final))
+	require.NotNil(t, final.Status)
+	assert.Equal(t, clientjob.Succeeded, *final.Status)
+	assert.Contains(t, result.Stderr, "Waiting for job")
+	assert.Equal(t, 1, server.Jobs.CreateRequestCount())
+	assert.Equal(t, 3, server.Jobs.RetrieveRequestCount())
+}
+
+func TestJobCreateFailedAndCanceledReturnNonzero(t *testing.T) {
+	for _, status := range []clientjob.JobStatus{clientjob.Failed, clientjob.Canceled} {
+		t.Run(string(status), func(t *testing.T) {
+			server := renderapi.NewServer(t)
+			server.Jobs.QueueStatuses(pointers.From(status))
+			result, err := executeJobCreateCommand(t, server, context.Background(), 0,
+				"srv-jobcreate000000000", "--wait", "--output", "json")
+			require.Error(t, err)
+			var exitCoder command.ExitCoder
+			require.ErrorAs(t, err, &exitCoder)
+			assert.Equal(t, 1, exitCoder.ExitCode())
+			assert.Equal(t, 1, exitCodeFromError(err))
+			var final clientjob.Job
+			require.NoError(t, json.Unmarshal([]byte(result.Stdout), &final))
+			require.NotNil(t, final.Status)
+			assert.Equal(t, status, *final.Status)
+			assert.Equal(t, 1, server.Jobs.CreateRequestCount())
+		})
+	}
+}
+
+func TestJobCreateRetriesRetrieveButNeverCreate(t *testing.T) {
+	t.Run("retrieve 503 is retried", func(t *testing.T) {
+		server := renderapi.NewServer(t)
+		server.Jobs.RespondRetrieveWith(503)
+		server.Jobs.QueueStatuses(pointers.From(clientjob.Succeeded))
+		_, err := executeJobCreateCommand(t, server, context.Background(), 1,
+			"srv-jobcreate000000000", "--wait", "--output", "text")
+		require.NoError(t, err)
+		assert.Equal(t, 1, server.Jobs.CreateRequestCount())
+		assert.Equal(t, 2, server.Jobs.RetrieveRequestCount())
+	})
+
+	t.Run("create 503 is not retried", func(t *testing.T) {
+		server := renderapi.NewServer(t)
+		server.Jobs.RespondCreateWith(503)
+		_, err := executeJobCreateCommand(t, server, context.Background(), 3,
+			"srv-jobcreate000000000", "--wait", "--output", "text")
+		require.Error(t, err)
+		assert.Equal(t, 1, server.Jobs.CreateRequestCount())
+		assert.Zero(t, server.Jobs.RetrieveRequestCount())
+	})
+}
+
+func TestJobCreateTimeoutAndValidation(t *testing.T) {
+	t.Run("timeout stops polling", func(t *testing.T) {
+		server := renderapi.NewServer(t)
+		server.Jobs.QueueStatuses(pointers.From(clientjob.Running))
+		_, err := executeJobCreateCommand(t, server, context.Background(), 0,
+			"srv-jobcreate000000000", "--wait", "--timeout", "1ns", "--output", "text")
+		require.ErrorContains(t, err, "timed out waiting for job")
+		assert.Equal(t, 1, server.Jobs.CreateRequestCount())
+	})
+
+	t.Run("timeout requires wait or tail", func(t *testing.T) {
+		server := renderapi.NewServer(t)
+		_, err := executeJobCreateCommand(t, server, context.Background(), 0,
+			"srv-jobcreate000000000", "--timeout", "1m", "--output", "text")
+		require.EqualError(t, err, "--timeout requires --wait or --tail")
+		assert.Zero(t, server.Jobs.CreateRequestCount())
+	})
+
+	t.Run("timeout must be positive", func(t *testing.T) {
+		server := renderapi.NewServer(t)
+		_, err := executeJobCreateCommand(t, server, context.Background(), 0,
+			"srv-jobcreate000000000", "--wait", "--timeout", "0s", "--output", "text")
+		require.EqualError(t, err, "--timeout must be positive")
+		assert.Zero(t, server.Jobs.CreateRequestCount())
+	})
+}
+
+func TestJobCreateContextCancellationStopsPolling(t *testing.T) {
+	server := renderapi.NewServer(t)
+	server.Jobs.QueueStatuses(pointers.From(clientjob.Running))
+	ctx, cancel := context.WithCancel(context.Background())
+	ticker := newJobCommandTicker(0)
+	root, _, _ := prepareJobCreateCommand(t, server, ctx, ticker,
+		"srv-jobcreate000000000", "--wait", "--output", "text")
+	result := make(chan error, 1)
+	go func() { result <- root.Execute() }()
+	<-server.Jobs.Retrieved()
+	cancel()
+	err := <-result
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.Canceled), err)
+	assert.Equal(t, 1, server.Jobs.CreateRequestCount())
+	assert.Equal(t, 1, server.Jobs.RetrieveRequestCount())
+}
+
+func TestJobCreateTailCancellationStopsPollingAndStreaming(t *testing.T) {
+	server := renderapi.NewServer(t)
+	server.Jobs.QueueStatuses(pointers.From(clientjob.Running))
+	server.Logs.QueueStream(renderapi.LogStreamAttempt{HoldOpen: true})
+	ctx, cancel := context.WithCancel(context.Background())
+	ticker := newJobCommandTicker(0)
+	root, _, _ := prepareJobCreateCommand(t, server, ctx, ticker,
+		"srv-jobcreate000000000", "--tail", "--output", "text")
+	result := make(chan error, 1)
+	go func() { result <- root.Execute() }()
+	<-server.Logs.Opened()
+	<-server.Jobs.Retrieved()
+	cancel()
+	err := <-result
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.Canceled), err)
+	<-server.Logs.Closed()
+	assert.Equal(t, 1, server.Jobs.CreateRequestCount())
+	assert.Equal(t, 1, server.Jobs.RetrieveRequestCount())
+}
+
+func TestJobCreateRejectsMissingAndUnknownStatuses(t *testing.T) {
+	unknown := clientjob.JobStatus("paused")
+	for name, status := range map[string]*clientjob.JobStatus{"missing": nil, "unknown": &unknown} {
+		t.Run(name, func(t *testing.T) {
+			server := renderapi.NewServer(t)
+			server.Jobs.QueueStatuses(status)
+			_, err := executeJobCreateCommand(t, server, context.Background(), 0,
+				"srv-jobcreate000000000", "--wait", "--output", "text")
+			require.Error(t, err)
+			var statusErr *job.StatusError
+			require.ErrorAs(t, err, &statusErr)
+			assert.Equal(t, 1, server.Jobs.RetrieveRequestCount())
+		})
+	}
+}
+
+func TestJobCreateWaitYAMLOutputIsOneDocument(t *testing.T) {
+	server := renderapi.NewServer(t)
+	server.Jobs.QueueStatuses(pointers.From(clientjob.Succeeded))
+	result, err := executeJobCreateCommand(t, server, context.Background(), 0,
+		"srv-jobcreate000000000", "--wait", "--output", "yaml")
+	require.NoError(t, err)
+	var final map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(result.Stdout), &final))
+	assert.Equal(t, "succeeded", final["status"])
+	assert.NotContains(t, result.Stdout, "Waiting for job")
+}

--- a/internal/fakes/renderapi/jobs.go
+++ b/internal/fakes/renderapi/jobs.go
@@ -1,0 +1,158 @@
+package renderapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/render-oss/cli/internal/testids"
+	"github.com/render-oss/cli/pkg/client"
+	clientjob "github.com/render-oss/cli/pkg/client/jobs"
+	"github.com/render-oss/cli/pkg/pointers"
+)
+
+type jobRetrieveResponse struct {
+	statusCode int
+	status     *clientjob.JobStatus
+}
+
+// JobResource holds one-off job state and deterministic response queues.
+type JobResource struct {
+	Resource[*clientjob.Job]
+	mu                sync.Mutex
+	createErrors      []int
+	retrieveResponses []jobRetrieveResponse
+	createRequests    int
+	retrieveRequests  int
+	retrieved         chan struct{}
+}
+
+func newJobResource() *JobResource {
+	return &JobResource{retrieved: make(chan struct{}, 16)}
+}
+
+// NewJob returns a one-off job with sensible defaults for zero-value fields.
+func NewJob(value clientjob.Job) *clientjob.Job {
+	if value.Id == "" {
+		value.Id = "job-fake0000000000000000"
+	}
+	if value.ServiceId == "" {
+		value.ServiceId = testids.RandomServiceID()
+	}
+	if value.PlanId == "" {
+		value.PlanId = "plan-srv-006"
+	}
+	if value.CreatedAt.IsZero() {
+		value.CreatedAt = time.Now().UTC()
+	}
+	if value.Status == nil {
+		value.Status = pointers.From(clientjob.Pending)
+	}
+	return &value
+}
+
+// RespondCreateWith queues an HTTP failure for the next create request.
+func (j *JobResource) RespondCreateWith(statusCode int) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	j.createErrors = append(j.createErrors, statusCode)
+}
+
+// QueueStatuses returns these statuses on successive retrieve requests.
+func (j *JobResource) QueueStatuses(statuses ...*clientjob.JobStatus) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	for _, status := range statuses {
+		j.retrieveResponses = append(j.retrieveResponses, jobRetrieveResponse{statusCode: http.StatusOK, status: status})
+	}
+}
+
+// RespondRetrieveWith queues an HTTP failure for the next retrieve request.
+func (j *JobResource) RespondRetrieveWith(statusCode int) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	j.retrieveResponses = append(j.retrieveResponses, jobRetrieveResponse{statusCode: statusCode})
+}
+
+func (j *JobResource) CreateRequestCount() int {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return j.createRequests
+}
+
+func (j *JobResource) RetrieveRequestCount() int {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return j.retrieveRequests
+}
+
+func (j *JobResource) Retrieved() <-chan struct{} { return j.retrieved }
+
+func (s *Server) registerJobRoutes(mux *http.ServeMux, record func(*http.Request)) {
+	mux.HandleFunc("POST /services/{serviceId}/jobs", func(w http.ResponseWriter, r *http.Request) {
+		record(r)
+		s.Jobs.mu.Lock()
+		defer s.Jobs.mu.Unlock()
+		s.Jobs.createRequests++
+		if len(s.Jobs.createErrors) > 0 {
+			statusCode := s.Jobs.createErrors[0]
+			s.Jobs.createErrors = s.Jobs.createErrors[1:]
+			message := http.StatusText(statusCode)
+			writeJSON(w, statusCode, client.Error{Message: &message})
+			return
+		}
+
+		var body client.PostJobJSONRequestBody
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		job := NewJob(clientjob.Job{
+			Id:           "job-fake0000000000000000",
+			ServiceId:    r.PathValue("serviceId"),
+			StartCommand: body.StartCommand,
+			PlanId:       pointers.ValueOrDefault(body.PlanId, "plan-srv-006"),
+		})
+		s.Jobs.Instances = append(s.Jobs.Instances, job)
+		writeJSON(w, http.StatusCreated, job)
+	})
+
+	mux.HandleFunc("GET /services/{serviceId}/jobs/{jobId}", func(w http.ResponseWriter, r *http.Request) {
+		record(r)
+		s.Jobs.mu.Lock()
+		defer s.Jobs.mu.Unlock()
+		s.Jobs.retrieveRequests++
+
+		var found *clientjob.Job
+		for _, candidate := range s.Jobs.Instances {
+			if candidate.Id == r.PathValue("jobId") && candidate.ServiceId == r.PathValue("serviceId") {
+				found = candidate
+				break
+			}
+		}
+		if found == nil {
+			message := "job not found"
+			writeJSON(w, http.StatusNotFound, client.Error{Message: &message})
+			return
+		}
+
+		if len(s.Jobs.retrieveResponses) > 0 {
+			response := s.Jobs.retrieveResponses[0]
+			s.Jobs.retrieveResponses = s.Jobs.retrieveResponses[1:]
+			if response.statusCode != http.StatusOK {
+				message := http.StatusText(response.statusCode)
+				writeJSON(w, response.statusCode, client.Error{Message: &message})
+				return
+			}
+			found.Status = response.status
+		}
+
+		copy := *found
+		writeJSON(w, http.StatusOK, &copy)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		s.Jobs.retrieved <- struct{}{}
+	})
+}

--- a/internal/fakes/renderapi/logs.go
+++ b/internal/fakes/renderapi/logs.go
@@ -1,0 +1,115 @@
+package renderapi
+
+import (
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	logclient "github.com/render-oss/cli/pkg/client/logs"
+)
+
+func deadlineSoon() time.Time { return time.Now().Add(time.Second) }
+
+// LogStreamAttempt scripts one websocket connection. A nonzero CloseCode ends
+// the attempt with that websocket close status. HoldOpen keeps the connection
+// alive until the client cancels it.
+type LogStreamAttempt struct {
+	Logs      []logclient.Log
+	CloseCode int
+	HoldOpen  bool
+}
+
+// LogResource holds scripted websocket attempts and observable lifecycle
+// events for command-level log-tail tests.
+type LogResource struct {
+	mu       sync.Mutex
+	attempts []LogStreamAttempt
+	queries  []url.Values
+	opened   chan struct{}
+	closed   chan struct{}
+}
+
+func newLogResource() *LogResource {
+	return &LogResource{opened: make(chan struct{}, 16), closed: make(chan struct{}, 16)}
+}
+
+func (l *LogResource) QueueStream(attempts ...LogStreamAttempt) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.attempts = append(l.attempts, attempts...)
+}
+
+func (l *LogResource) StreamRequestCount() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.queries)
+}
+
+func (l *LogResource) Query(index int) url.Values {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.queries[index]
+}
+
+func (l *LogResource) Opened() <-chan struct{} { return l.opened }
+func (l *LogResource) Closed() <-chan struct{} { return l.closed }
+
+func (l *LogResource) nextAttempt(query url.Values) LogStreamAttempt {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.queries = append(l.queries, query)
+	if len(l.attempts) == 0 {
+		return LogStreamAttempt{HoldOpen: true}
+	}
+	attempt := l.attempts[0]
+	l.attempts = l.attempts[1:]
+	return attempt
+}
+
+func (s *Server) registerLogRoutes(mux *http.ServeMux, record func(*http.Request)) {
+	upgrader := websocket.Upgrader{}
+	mux.HandleFunc("GET /logs/subscribe", func(w http.ResponseWriter, r *http.Request) {
+		record(r)
+		attempt := s.Logs.nextAttempt(r.URL.Query())
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		s.Logs.opened <- struct{}{}
+		defer func() {
+			_ = conn.Close()
+			s.Logs.closed <- struct{}{}
+		}()
+
+		for i := range attempt.Logs {
+			if err := conn.WriteJSON(&attempt.Logs[i]); err != nil {
+				return
+			}
+		}
+		if attempt.CloseCode != 0 {
+			_ = conn.WriteControl(
+				websocket.CloseMessage,
+				websocket.FormatCloseMessage(attempt.CloseCode, "scripted disconnect"),
+				deadlineSoon(),
+			)
+			return
+		}
+		if !attempt.HoldOpen {
+			_ = conn.WriteControl(
+				websocket.CloseMessage,
+				websocket.FormatCloseMessage(websocket.CloseNormalClosure, "complete"),
+				deadlineSoon(),
+			)
+			return
+		}
+
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	})
+}

--- a/internal/fakes/renderapi/server.go
+++ b/internal/fakes/renderapi/server.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -296,6 +297,7 @@ func NewUser(u client.User) client.User {
 type Server struct {
 	server        *httptest.Server
 	Requests      []RecordedRequest
+	requestsMu    sync.Mutex
 	CurrentUser   *client.User
 	Owners        *Resource[*client.Owner]
 	Projects      *Resource[*client.Project]
@@ -307,6 +309,8 @@ type Server struct {
 	SandboxGroups *SandboxGroupResource
 	CliTelemetry  *CliTelemetryResource
 	OAuth         *OAuthResource
+	Jobs          *JobResource
+	Logs          *LogResource
 }
 
 // ownerByID returns the Owner with the given ID from the seeded owners. The
@@ -365,6 +369,8 @@ func (s *Server) SetCurrentUser(u client.User) client.User {
 
 // HasRequest returns true if any recorded request matches the given method and URI substring.
 func (s *Server) HasRequest(method, uriSubstring string) bool {
+	s.requestsMu.Lock()
+	defer s.requestsMu.Unlock()
 	for _, r := range s.Requests {
 		if r.Method == method && strings.Contains(r.URI, uriSubstring) {
 			return true
@@ -378,6 +384,8 @@ func (s *Server) HasRequest(method, uriSubstring string) bool {
 // is robust when a command issues several requests (e.g. GETs to resolve a
 // service before the PATCH).
 func (s *Server) LastRequest(method, uriSubstring string) (RecordedRequest, bool) {
+	s.requestsMu.Lock()
+	defer s.requestsMu.Unlock()
 	for i := len(s.Requests) - 1; i >= 0; i-- {
 		r := s.Requests[i]
 		if r.Method == method && strings.Contains(r.URI, uriSubstring) {
@@ -389,6 +397,8 @@ func (s *Server) LastRequest(method, uriSubstring string) (RecordedRequest, bool
 
 // HasDeleteRequest returns true if any recorded request used the DELETE method.
 func (s *Server) HasDeleteRequest() bool {
+	s.requestsMu.Lock()
+	defer s.requestsMu.Unlock()
 	for _, r := range s.Requests {
 		if r.Method == http.MethodDelete {
 			return true
@@ -413,11 +423,15 @@ func NewServer(t *testing.T) *Server {
 		SandboxGroups: &SandboxGroupResource{},
 		CliTelemetry:  &CliTelemetryResource{},
 		OAuth:         &OAuthResource{},
+		Jobs:          newJobResource(),
+		Logs:          newLogResource(),
 	}
 
 	mux := http.NewServeMux()
 
 	record := func(r *http.Request) {
+		s.requestsMu.Lock()
+		defer s.requestsMu.Unlock()
 		rec := RecordedRequest{Method: r.Method, URI: r.URL.RequestURI()}
 		if r.Body != nil {
 			if body, err := io.ReadAll(r.Body); err == nil {
@@ -428,6 +442,9 @@ func NewServer(t *testing.T) *Server {
 		}
 		s.Requests = append(s.Requests, rec)
 	}
+
+	s.registerJobRoutes(mux, record)
+	s.registerLogRoutes(mux, record)
 
 	// GET /users - retrieve the authenticated user.
 	mux.HandleFunc("/users", func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/dependencies/dependencies.go
+++ b/pkg/dependencies/dependencies.go
@@ -9,6 +9,7 @@ import (
 	"github.com/render-oss/cli/pkg/config"
 	"github.com/render-oss/cli/pkg/deploy"
 	"github.com/render-oss/cli/pkg/environment"
+	"github.com/render-oss/cli/pkg/job"
 	"github.com/render-oss/cli/pkg/keyvalue"
 	"github.com/render-oss/cli/pkg/logs"
 	"github.com/render-oss/cli/pkg/owner"
@@ -56,6 +57,7 @@ type cachedDependencies struct {
 	sandboxRepo         cache[*sandbox.Repo]
 	sandboxGroupRepo    cache[*sandboxgroup.Repo]
 	keyValueRepo        cache[*keyvalue.Repo]
+	jobRepo             cache[*job.Repo]
 	userRepo            cache[*user.Repo]
 	ownerRepo           cache[*owner.Repo]
 	deployRepo          cache[*deploy.Repo]
@@ -171,6 +173,12 @@ func (d *Dependencies) SandboxGroupRepo() *sandboxgroup.Repo {
 func (d *Dependencies) KeyValueRepo() *keyvalue.Repo {
 	return d.cache.keyValueRepo.Get(func() *keyvalue.Repo {
 		return keyvalue.NewRepo(d.client)
+	})
+}
+
+func (d *Dependencies) JobRepo() *job.Repo {
+	return d.cache.jobRepo.Get(func() *job.Repo {
+		return job.NewRepo(d.client)
 	})
 }
 

--- a/pkg/job/repo.go
+++ b/pkg/job/repo.go
@@ -14,6 +14,16 @@ type Repo struct {
 	client *client.ClientWithResponses
 }
 
+// HTTPError preserves a retrieve response's status code so polling can retry
+// only explicitly transient API failures.
+type HTTPError struct {
+	StatusCode int
+	Err        error
+}
+
+func (e *HTTPError) Error() string { return e.Err.Error() }
+func (e *HTTPError) Unwrap() error { return e.Err }
+
 func NewRepo(c *client.ClientWithResponses) *Repo {
 	return &Repo{client: c}
 }
@@ -131,7 +141,7 @@ func (r *Repo) GetJob(ctx context.Context, serviceID, jobID string) (*clientjob.
 	}
 
 	if err := client.ErrorFromResponse(resp); err != nil {
-		return nil, err
+		return nil, &HTTPError{StatusCode: resp.StatusCode(), Err: err}
 	}
 
 	return resp.JSON200, nil

--- a/pkg/job/runner.go
+++ b/pkg/job/runner.go
@@ -1,0 +1,349 @@
+package job
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"syscall"
+	"time"
+
+	"github.com/render-oss/cli/pkg/client"
+	clientjob "github.com/render-oss/cli/pkg/client/jobs"
+	logclient "github.com/render-oss/cli/pkg/client/logs"
+	"github.com/render-oss/cli/pkg/logs"
+)
+
+const (
+	DefaultPollInterval      = 2 * time.Second
+	DefaultTimeout           = 30 * time.Minute
+	DefaultTransientAttempts = 3
+)
+
+// TerminalError reports a completed job whose status should fail a CI step.
+// The final Job remains available so the command can print it before returning
+// the nonzero result through Cobra.
+type TerminalError struct {
+	Job *clientjob.Job
+}
+
+func (e *TerminalError) Error() string {
+	return fmt.Sprintf("job %s finished with status %s", e.Job.Id, statusName(e.Job.Status))
+}
+
+// StatusError reports a missing or unrecognized job status. Treating these as
+// errors prevents an API/schema mismatch from producing an infinite wait.
+type StatusError struct {
+	JobID  string
+	Status *clientjob.JobStatus
+}
+
+func (e *StatusError) Error() string {
+	if e.Status == nil {
+		return fmt.Sprintf("job %s returned no status", e.JobID)
+	}
+	return fmt.Sprintf("job %s returned unknown status %q", e.JobID, *e.Status)
+}
+
+// TickSource is the small portion of time.Ticker needed by Runner. Tests use a
+// manually driven implementation, so state transitions never require sleeps.
+type TickSource interface {
+	C() <-chan time.Time
+	Stop()
+}
+
+type realTicker struct{ ticker *time.Ticker }
+
+func (t realTicker) C() <-chan time.Time { return t.ticker.C }
+func (t realTicker) Stop()               { t.ticker.Stop() }
+
+// OpenLogStream opens a read-only stream beginning at startTime. A reconnect
+// receives the last observed timestamp and relies on log ID deduplication to
+// handle inclusive server cursors.
+type OpenLogStream func(ctx context.Context, startTime *time.Time) (*logs.TailStream, error)
+
+// Runner coordinates job status polling with the existing live log stream.
+type Runner struct {
+	Retrieve             func(context.Context) (*clientjob.Job, error)
+	OpenLogs             OpenLogStream
+	PollInterval         time.Duration
+	MaxTransientAttempts int
+	NewTicker            func(time.Duration) TickSource
+	OnLog                func(*logclient.Log) error
+	OnRetry              func(string)
+}
+
+// Run waits for a terminal status. tail controls whether the existing log
+// stream is opened alongside status polling.
+func (r Runner) Run(ctx context.Context, jobID string, tail bool, timeout time.Duration) (*clientjob.Job, error) {
+	if timeout <= 0 {
+		return nil, fmt.Errorf("timeout must be positive")
+	}
+	if r.Retrieve == nil {
+		return nil, errors.New("job status retriever is required")
+	}
+	if tail && r.OpenLogs == nil {
+		return nil, errors.New("job log stream is required when tailing")
+	}
+
+	pollInterval := r.PollInterval
+	if pollInterval <= 0 {
+		pollInterval = DefaultPollInterval
+	}
+	maxTransientAttempts := r.MaxTransientAttempts
+	if maxTransientAttempts <= 0 {
+		maxTransientAttempts = DefaultTransientAttempts
+	}
+	newTicker := r.NewTicker
+	if newTicker == nil {
+		newTicker = func(interval time.Duration) TickSource {
+			return realTicker{ticker: time.NewTicker(interval)}
+		}
+	}
+
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := newTicker(pollInterval)
+	defer ticker.Stop()
+
+	seenLogs := make(map[string]struct{})
+	var lastLogTime *time.Time
+	var logStream *logs.TailStream
+	var stopLogs context.CancelFunc
+	var reconnectLogs bool
+	var allowReconnect bool
+	var statusFailures int
+	var streamFailures int
+
+	closeLogStream := func() {
+		if stopLogs != nil {
+			stopLogs()
+			stopLogs = nil
+		}
+	}
+	defer closeLogStream()
+
+	openLogs := func() error {
+		streamCtx, streamCancel := context.WithCancel(runCtx)
+		stream, err := r.OpenLogs(streamCtx, lastLogTime)
+		if err != nil {
+			streamCancel()
+			return err
+		}
+		closeLogStream()
+		stopLogs = streamCancel
+		logStream = stream
+		reconnectLogs = false
+		return nil
+	}
+
+	if tail {
+		if err := openLogs(); err != nil {
+			if !logs.IsTransientStreamError(err) {
+				return nil, err
+			}
+			streamFailures++
+			reconnectLogs = true
+			r.reportRetry(fmt.Sprintf("log stream failed; retrying (%d/%d): %v", streamFailures, maxTransientAttempts, err))
+		}
+	}
+
+	poll := true
+	for {
+		if tail && reconnectLogs && allowReconnect {
+			allowReconnect = false
+			if streamFailures > maxTransientAttempts {
+				return nil, fmt.Errorf("tail logs for job %s: transient failure persisted after %d retries", jobID, maxTransientAttempts)
+			}
+			if err := openLogs(); err != nil {
+				if !logs.IsTransientStreamError(err) {
+					return nil, err
+				}
+				streamFailures++
+				if streamFailures > maxTransientAttempts {
+					return nil, fmt.Errorf("tail logs for job %s: transient failure persisted after %d retries: %w", jobID, maxTransientAttempts, err)
+				}
+				r.reportRetry(fmt.Sprintf("log stream failed; retrying (%d/%d): %v", streamFailures, maxTransientAttempts, err))
+			} else {
+				streamFailures = 0
+			}
+		}
+
+		if poll {
+			current, err := r.Retrieve(runCtx)
+			if err != nil {
+				if runCtx.Err() != nil {
+					return nil, waitContextError(runCtx, jobID, timeout)
+				}
+				if !isTransientRetrieveError(err) {
+					return nil, fmt.Errorf("retrieve job %s: %w", jobID, err)
+				}
+				statusFailures++
+				if statusFailures > maxTransientAttempts {
+					return nil, fmt.Errorf("retrieve job %s: transient failure persisted after %d retries: %w", jobID, maxTransientAttempts, err)
+				}
+				r.reportRetry(fmt.Sprintf("job status failed; retrying (%d/%d): %v", statusFailures, maxTransientAttempts, err))
+			} else {
+				statusFailures = 0
+				done, terminalErr := terminalResult(current)
+				if done {
+					closeLogStream()
+					if err := r.drainBufferedLogs(logStream, seenLogs, &lastLogTime); err != nil {
+						return current, err
+					}
+					return current, terminalErr
+				}
+			}
+			poll = false
+		}
+
+		var logCh <-chan *logclient.Log
+		var logErrCh <-chan error
+		if logStream != nil {
+			logCh = logStream.Logs
+			logErrCh = logStream.Errors
+		}
+
+		select {
+		case <-runCtx.Done():
+			closeLogStream()
+			if err := r.drainBufferedLogs(logStream, seenLogs, &lastLogTime); err != nil {
+				return nil, err
+			}
+			return nil, waitContextError(runCtx, jobID, timeout)
+		case <-ticker.C():
+			poll = true
+			allowReconnect = true
+		case entry, ok := <-logCh:
+			if !ok {
+				if logStream != nil {
+					logStream.Logs = nil
+				}
+				continue
+			}
+			if err := r.emitLog(entry, seenLogs, &lastLogTime); err != nil {
+				return nil, err
+			}
+		case streamErr, ok := <-logErrCh:
+			if !ok {
+				if logStream != nil {
+					logStream.Errors = nil
+				}
+				continue
+			}
+			closeLogStream()
+			if err := r.drainBufferedLogs(logStream, seenLogs, &lastLogTime); err != nil {
+				return nil, err
+			}
+			logStream = nil
+			if !logs.IsTransientStreamError(streamErr) {
+				return nil, fmt.Errorf("tail logs for job %s: %w", jobID, streamErr)
+			}
+			streamFailures++
+			reconnectLogs = true
+			r.reportRetry(fmt.Sprintf("log stream disconnected; retrying (%d/%d): %v", streamFailures, maxTransientAttempts, streamErr))
+		}
+	}
+}
+
+func waitContextError(ctx context.Context, jobID string, timeout time.Duration) error {
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return fmt.Errorf("timed out waiting for job %s after %s", jobID, timeout)
+	}
+	return fmt.Errorf("waiting for job %s canceled: %w", jobID, ctx.Err())
+}
+
+func (r Runner) emitLog(entry *logclient.Log, seen map[string]struct{}, lastLogTime **time.Time) error {
+	if entry == nil {
+		return nil
+	}
+	key := entry.Id
+	if key == "" {
+		key = entry.Timestamp.UTC().Format(time.RFC3339Nano) + "\x00" + entry.Message
+	}
+	if _, exists := seen[key]; exists {
+		return nil
+	}
+	seen[key] = struct{}{}
+	timestamp := entry.Timestamp
+	*lastLogTime = &timestamp
+	if r.OnLog != nil {
+		return r.OnLog(entry)
+	}
+	return nil
+}
+
+func (r Runner) drainBufferedLogs(stream *logs.TailStream, seen map[string]struct{}, lastLogTime **time.Time) error {
+	if stream == nil {
+		return nil
+	}
+	for stream.Logs != nil {
+		select {
+		case entry, ok := <-stream.Logs:
+			if !ok {
+				stream.Logs = nil
+				continue
+			}
+			if err := r.emitLog(entry, seen, lastLogTime); err != nil {
+				return err
+			}
+		default:
+			return nil
+		}
+	}
+	return nil
+}
+
+func (r Runner) reportRetry(message string) {
+	if r.OnRetry != nil {
+		r.OnRetry(message)
+	}
+}
+
+func terminalResult(current *clientjob.Job) (bool, error) {
+	if current == nil {
+		return true, errors.New("retrieve job returned an empty response")
+	}
+	if current.Status == nil {
+		return true, &StatusError{JobID: current.Id}
+	}
+	switch *current.Status {
+	case clientjob.Pending, clientjob.Running:
+		return false, nil
+	case clientjob.Succeeded:
+		return true, nil
+	case clientjob.Failed, clientjob.Canceled:
+		return true, &TerminalError{Job: current}
+	default:
+		return true, &StatusError{JobID: current.Id, Status: current.Status}
+	}
+}
+
+func statusName(status *clientjob.JobStatus) string {
+	if status == nil {
+		return "unknown"
+	}
+	return string(*status)
+}
+
+func isTransientRetrieveError(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	if errors.Is(err, client.ErrTooManyRequests) {
+		return true
+	}
+	var responseErr *HTTPError
+	if errors.As(err, &responseErr) {
+		return responseErr.StatusCode == http.StatusTooManyRequests || responseErr.StatusCode >= http.StatusInternalServerError
+	}
+	var netErr net.Error
+	return (errors.As(err, &netErr) && netErr.Timeout()) ||
+		errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.ECONNREFUSED) ||
+		errors.Is(err, syscall.ECONNABORTED)
+}

--- a/pkg/job/runner_test.go
+++ b/pkg/job/runner_test.go
@@ -1,0 +1,307 @@
+package job
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	clientjob "github.com/render-oss/cli/pkg/client/jobs"
+	logclient "github.com/render-oss/cli/pkg/client/logs"
+	"github.com/render-oss/cli/pkg/logs"
+	"github.com/render-oss/cli/pkg/pointers"
+)
+
+type manualTicker struct{ ticks chan time.Time }
+
+func newManualTicker(buffer int) *manualTicker {
+	return &manualTicker{ticks: make(chan time.Time, buffer)}
+}
+
+func (t *manualTicker) C() <-chan time.Time { return t.ticks }
+func (t *manualTicker) Stop()               {}
+func (t *manualTicker) Tick()               { t.ticks <- time.Time{} }
+
+func jobWithStatus(status *clientjob.JobStatus) *clientjob.Job {
+	return &clientjob.Job{Id: "job-test", Status: status}
+}
+
+func sequenceRetriever(results ...*clientjob.Job) func(context.Context) (*clientjob.Job, error) {
+	var mu sync.Mutex
+	index := 0
+	return func(context.Context) (*clientjob.Job, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if index >= len(results) {
+			return results[len(results)-1], nil
+		}
+		result := results[index]
+		index++
+		return result, nil
+	}
+}
+
+func TestRunnerWaitsForSucceededJobWithoutSleeping(t *testing.T) {
+	ticker := newManualTicker(2)
+	ticker.Tick()
+	ticker.Tick()
+	runner := Runner{
+		Retrieve: sequenceRetriever(
+			jobWithStatus(pointers.From(clientjob.Pending)),
+			jobWithStatus(pointers.From(clientjob.Running)),
+			jobWithStatus(pointers.From(clientjob.Succeeded)),
+		),
+		NewTicker: func(time.Duration) TickSource { return ticker },
+	}
+
+	result, err := runner.Run(context.Background(), "job-test", false, time.Minute)
+	require.NoError(t, err)
+	require.NotNil(t, result.Status)
+	assert.Equal(t, clientjob.Succeeded, *result.Status)
+}
+
+func TestRunnerReturnsTerminalErrors(t *testing.T) {
+	for _, status := range []clientjob.JobStatus{clientjob.Failed, clientjob.Canceled} {
+		t.Run(string(status), func(t *testing.T) {
+			runner := Runner{Retrieve: sequenceRetriever(jobWithStatus(pointers.From(status)))}
+			result, err := runner.Run(context.Background(), "job-test", false, time.Minute)
+			var terminalErr *TerminalError
+			require.ErrorAs(t, err, &terminalErr)
+			assert.Same(t, result, terminalErr.Job)
+		})
+	}
+}
+
+func TestRunnerRejectsMissingAndUnknownStatuses(t *testing.T) {
+	unknown := clientjob.JobStatus("paused")
+	for name, status := range map[string]*clientjob.JobStatus{"missing": nil, "unknown": &unknown} {
+		t.Run(name, func(t *testing.T) {
+			runner := Runner{Retrieve: sequenceRetriever(jobWithStatus(status))}
+			_, err := runner.Run(context.Background(), "job-test", false, time.Minute)
+			var statusErr *StatusError
+			require.ErrorAs(t, err, &statusErr)
+		})
+	}
+}
+
+func TestRunnerRetriesBoundedTransientRetrieveFailure(t *testing.T) {
+	ticker := newManualTicker(1)
+	ticker.Tick()
+	calls := 0
+	runner := Runner{
+		Retrieve: func(context.Context) (*clientjob.Job, error) {
+			calls++
+			if calls == 1 {
+				return nil, &HTTPError{StatusCode: http.StatusServiceUnavailable, Err: errors.New("try later")}
+			}
+			return jobWithStatus(pointers.From(clientjob.Succeeded)), nil
+		},
+		NewTicker: func(time.Duration) TickSource { return ticker },
+	}
+
+	_, err := runner.Run(context.Background(), "job-test", false, time.Minute)
+	require.NoError(t, err)
+	assert.Equal(t, 2, calls)
+}
+
+func TestRunnerRetriesTimeoutNetworkFailure(t *testing.T) {
+	ticker := newManualTicker(1)
+	ticker.Tick()
+	calls := 0
+	runner := Runner{
+		Retrieve: func(context.Context) (*clientjob.Job, error) {
+			calls++
+			if calls == 1 {
+				return nil, &net.DNSError{Err: "timeout", IsTimeout: true}
+			}
+			return jobWithStatus(pointers.From(clientjob.Succeeded)), nil
+		},
+		NewTicker: func(time.Duration) TickSource { return ticker },
+	}
+
+	_, err := runner.Run(context.Background(), "job-test", false, time.Minute)
+	require.NoError(t, err)
+	assert.Equal(t, 2, calls)
+}
+
+func TestRunnerStopsAfterTransientRetryLimit(t *testing.T) {
+	ticker := newManualTicker(DefaultTransientAttempts)
+	for range DefaultTransientAttempts {
+		ticker.Tick()
+	}
+	calls := 0
+	runner := Runner{
+		Retrieve: func(context.Context) (*clientjob.Job, error) {
+			calls++
+			return nil, &HTTPError{StatusCode: http.StatusTooManyRequests, Err: errors.New("rate limited")}
+		},
+		NewTicker: func(time.Duration) TickSource { return ticker },
+	}
+
+	_, err := runner.Run(context.Background(), "job-test", false, time.Minute)
+	require.ErrorContains(t, err, "persisted after 3 retries")
+	assert.Equal(t, DefaultTransientAttempts+1, calls)
+}
+
+func TestRunnerStopsAfterTransientLogRetryLimit(t *testing.T) {
+	ticker := newManualTicker(DefaultTransientAttempts)
+	for range DefaultTransientAttempts {
+		ticker.Tick()
+	}
+	openCalls := 0
+	runner := Runner{
+		Retrieve: sequenceRetriever(jobWithStatus(pointers.From(clientjob.Running))),
+		OpenLogs: func(context.Context, *time.Time) (*logs.TailStream, error) {
+			openCalls++
+			return nil, &logs.StreamError{Err: errors.New("temporary disconnect"), Transient: true}
+		},
+		NewTicker: func(time.Duration) TickSource { return ticker },
+	}
+
+	_, err := runner.Run(context.Background(), "job-test", true, time.Minute)
+	require.ErrorContains(t, err, "persisted after 3 retries")
+	assert.Equal(t, DefaultTransientAttempts+1, openCalls)
+}
+
+func TestRunnerCancellationStopsWaiting(t *testing.T) {
+	ticker := newManualTicker(0)
+	ctx, cancel := context.WithCancel(context.Background())
+	started := make(chan struct{})
+	runner := Runner{
+		Retrieve: func(context.Context) (*clientjob.Job, error) {
+			close(started)
+			return jobWithStatus(pointers.From(clientjob.Running)), nil
+		},
+		NewTicker: func(time.Duration) TickSource { return ticker },
+	}
+
+	result := make(chan error, 1)
+	go func() {
+		_, err := runner.Run(ctx, "job-test", false, time.Minute)
+		result <- err
+	}()
+	<-started
+	cancel()
+	require.ErrorContains(t, <-result, "canceled")
+}
+
+func TestRunnerTimeoutStopsWaiting(t *testing.T) {
+	runner := Runner{Retrieve: sequenceRetriever(jobWithStatus(pointers.From(clientjob.Running)))}
+	_, err := runner.Run(context.Background(), "job-test", false, time.Nanosecond)
+	require.ErrorContains(t, err, "timed out waiting for job job-test")
+}
+
+func TestRunnerCancellationAndTimeoutStopLogWorkers(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		timeout time.Duration
+		cancel  bool
+	}{
+		{name: "cancellation", timeout: time.Minute, cancel: true},
+		{name: "timeout", timeout: time.Nanosecond},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			opened := make(chan struct{})
+			stopped := make(chan struct{})
+			runner := Runner{
+				Retrieve: sequenceRetriever(jobWithStatus(pointers.From(clientjob.Running))),
+				OpenLogs: func(streamCtx context.Context, _ *time.Time) (*logs.TailStream, error) {
+					close(opened)
+					go func() {
+						<-streamCtx.Done()
+						close(stopped)
+					}()
+					return &logs.TailStream{
+						Logs:   make(chan *logclient.Log),
+						Errors: make(chan error),
+					}, nil
+				},
+			}
+			result := make(chan error, 1)
+			go func() {
+				_, err := runner.Run(ctx, "job-test", true, tc.timeout)
+				result <- err
+			}()
+			<-opened
+			if tc.cancel {
+				cancel()
+			}
+			require.Error(t, <-result)
+			<-stopped
+		})
+	}
+}
+
+func TestRunnerReconnectsTailWithoutDuplicatingLogs(t *testing.T) {
+	ticker := newManualTicker(0)
+	firstLogs := make(chan *logclient.Log, 2)
+	firstErrors := make(chan error, 1)
+	secondLogs := make(chan *logclient.Log, 2)
+	secondErrors := make(chan error)
+	now := time.Unix(100, 0).UTC()
+	firstLogs <- &logclient.Log{Id: "log-1", Message: "first", Timestamp: now}
+	firstLogs <- &logclient.Log{Id: "log-2", Message: "second", Timestamp: now.Add(time.Second)}
+	firstErrors <- &logs.StreamError{Err: errors.New("temporary disconnect"), Transient: true}
+
+	opened := make(chan int, 2)
+	openCalls := 0
+	var resumedAt *time.Time
+	streamClosed := make(chan struct{})
+	runner := Runner{
+		Retrieve: sequenceRetriever(
+			jobWithStatus(pointers.From(clientjob.Running)),
+			jobWithStatus(pointers.From(clientjob.Succeeded)),
+		),
+		OpenLogs: func(ctx context.Context, start *time.Time) (*logs.TailStream, error) {
+			openCalls++
+			if openCalls == 1 {
+				opened <- openCalls
+				return &logs.TailStream{Logs: firstLogs, Errors: firstErrors}, nil
+			}
+			resumedAt = start
+			secondLogs <- &logclient.Log{Id: "log-2", Message: "second", Timestamp: now.Add(time.Second)}
+			secondLogs <- &logclient.Log{Id: "log-3", Message: "third", Timestamp: now.Add(2 * time.Second)}
+			go func() {
+				<-ctx.Done()
+				close(streamClosed)
+			}()
+			opened <- openCalls
+			return &logs.TailStream{Logs: secondLogs, Errors: secondErrors}, nil
+		},
+		NewTicker: func(time.Duration) TickSource { return ticker },
+	}
+
+	received := make(chan string, 4)
+	runner.OnLog = func(entry *logclient.Log) error {
+		received <- entry.Message
+		return nil
+	}
+
+	result := make(chan error, 1)
+	go func() {
+		_, err := runner.Run(context.Background(), "job-test", true, time.Minute)
+		result <- err
+	}()
+	require.Equal(t, 1, <-opened)
+	require.Equal(t, "first", <-received)
+	require.Equal(t, "second", <-received)
+	ticker.Tick() // permits the reconnect and the next status poll
+	require.Equal(t, 2, <-opened)
+	require.NotNil(t, resumedAt)
+	assert.Equal(t, now.Add(time.Second), *resumedAt)
+
+	require.Equal(t, "third", <-received)
+	require.NoError(t, <-result)
+	<-streamClosed
+	assert.Equal(t, 2, openCalls)
+	assert.Empty(t, received, fmt.Sprintf("unexpected duplicate log: %v", received))
+}

--- a/pkg/logs/repo.go
+++ b/pkg/logs/repo.go
@@ -3,9 +3,12 @@ package logs
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"syscall"
 
 	"github.com/gorilla/websocket"
 
@@ -23,6 +26,31 @@ type LogRepo struct {
 	apiConfig *config.APIConfig
 }
 
+// TailStream reports logs and the reason a live stream ended. Errors is
+// buffered so callers that only consume Logs (the legacy behavior) cannot
+// prevent the reader goroutine from exiting.
+type TailStream struct {
+	Logs   <-chan *lclient.Log
+	Errors <-chan error
+}
+
+// StreamError identifies whether reconnecting a log stream is safe. A stream
+// reconnect only repeats a read; it never repeats the mutation that created the
+// resource whose logs are being followed.
+type StreamError struct {
+	Err       error
+	Transient bool
+}
+
+func (e *StreamError) Error() string { return e.Err.Error() }
+func (e *StreamError) Unwrap() error { return e.Err }
+
+// IsTransientStreamError reports whether a stream failure is safe to retry.
+func IsTransientStreamError(err error) bool {
+	var streamErr *StreamError
+	return errors.As(err, &streamErr) && streamErr.Transient
+}
+
 func (l *LogRepo) ListLogs(ctx context.Context, params *client.ListLogsParams) (*client.Logs200Response, error) {
 	logs, err := l.c.ListLogsWithResponse(ctx, params)
 	if err != nil {
@@ -37,6 +65,16 @@ func (l *LogRepo) ListLogs(ctx context.Context, params *client.ListLogsParams) (
 }
 
 func (l *LogRepo) TailLogs(ctx context.Context, params *client.ListLogsParams) (<-chan *lclient.Log, error) {
+	stream, err := l.TailLogsWithErrors(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	return stream.Logs, nil
+}
+
+// TailLogsWithErrors opens the same websocket used by TailLogs while exposing
+// disconnect errors to callers that can safely reconnect.
+func (l *LogRepo) TailLogsWithErrors(ctx context.Context, params *client.ListLogsParams) (*TailStream, error) {
 	subscribeParams := client.SubscribeLogsParams(*params)
 	req, err := client.NewSubscribeLogsRequest(l.apiConfig.Host, &subscribeParams)
 	if err != nil {
@@ -53,7 +91,7 @@ func (l *LogRepo) TailLogs(ctx context.Context, params *client.ListLogsParams) (
 	}
 
 	// Establish WebSocket connection using the custom dialer
-	conn, resp, err := dialer.Dial(u.String(), client.AddHeaders(http.Header{}, l.apiConfig.Key))
+	conn, resp, err := dialer.DialContext(ctx, u.String(), client.AddHeaders(http.Header{}, l.apiConfig.Key))
 	if err != nil {
 		// Return the http error if it exists, fall back to the websocket error
 		if resp != nil && resp.StatusCode != http.StatusSwitchingProtocols {
@@ -62,38 +100,80 @@ func (l *LogRepo) TailLogs(ctx context.Context, params *client.ListLogsParams) (
 				return nil, err
 			}
 
-			return nil, fmt.Errorf("failed to tail logs: %s", body)
+			streamErr := &StreamError{
+				Err:       fmt.Errorf("failed to tail logs (HTTP %d): %s", resp.StatusCode, body),
+				Transient: resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= http.StatusInternalServerError,
+			}
+			return nil, streamErr
 		}
 
-		return nil, err
+		return nil, &StreamError{Err: err, Transient: isTransientStreamFailure(err)}
 	}
 
-	ch := make(chan *lclient.Log)
+	logs := make(chan *lclient.Log, 64)
+	errs := make(chan error, 1)
+	done := make(chan struct{})
+
+	// A websocket read may block indefinitely. Closing the connection on
+	// cancellation makes the read return and guarantees the worker can finish.
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = conn.Close()
+		case <-done:
+		}
+	}()
 
 	// Read messages from the WebSocket connection
-	go func(ctx context.Context) {
-		defer conn.Close()
-		defer close(ch)
+	go func() {
+		defer close(done)
+		defer func() { _ = conn.Close() }()
+		defer close(logs)
+		defer close(errs)
 		for {
+			_, message, err := conn.ReadMessage()
+			if err != nil {
+				if ctx.Err() == nil && !isNormalStreamClose(err) {
+					errs <- &StreamError{Err: err, Transient: isTransientStreamFailure(err)}
+				}
+				return
+			}
+
+			var log lclient.Log
+			if err := json.Unmarshal(message, &log); err != nil {
+				errs <- &StreamError{Err: fmt.Errorf("decode tailed log: %w", err), Transient: false}
+				return
+			}
+
 			select {
+			case logs <- &log:
 			case <-ctx.Done():
 				return
-			default:
-				_, message, err := conn.ReadMessage()
-				if err != nil {
-					return
-				}
-
-				var log lclient.Log
-				err = json.Unmarshal(message, &log)
-				if err != nil {
-					return
-				}
-
-				ch <- &log
 			}
 		}
-	}(ctx)
+	}()
 
-	return ch, nil
+	return &TailStream{Logs: logs, Errors: errs}, nil
+}
+
+func isNormalStreamClose(err error) bool {
+	return websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway)
+}
+
+func isTransientStreamFailure(err error) bool {
+	if websocket.IsCloseError(err,
+		websocket.CloseAbnormalClosure,
+		websocket.CloseInternalServerErr,
+		websocket.CloseServiceRestart,
+		websocket.CloseTryAgainLater,
+	) {
+		return true
+	}
+
+	var netErr net.Error
+	return (errors.As(err, &netErr) && netErr.Timeout()) ||
+		errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.ECONNREFUSED) ||
+		errors.Is(err, syscall.ECONNABORTED)
 }

--- a/pkg/logs/repo_test.go
+++ b/pkg/logs/repo_test.go
@@ -1,0 +1,15 @@
+package logs
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTransientStreamFailureClassification(t *testing.T) {
+	assert.True(t, isTransientStreamFailure(&websocket.CloseError{Code: websocket.CloseTryAgainLater}))
+	assert.False(t, isTransientStreamFailure(&websocket.CloseError{Code: websocket.CloseNormalClosure}))
+	assert.False(t, isTransientStreamFailure(errors.New("invalid log payload")))
+}

--- a/pkg/tui/views/logloader.go
+++ b/pkg/tui/views/logloader.go
@@ -54,6 +54,21 @@ func (l *LogLoader) LoadLogData(ctx context.Context, in LogInput) (*tui.LogResul
 	return &tui.LogResult{Logs: logs, LogChannel: nil}, nil
 }
 
+// LoadLogStream uses the same filtering and repository path as LoadLogData,
+// while retaining disconnect errors for callers that can safely reconnect.
+func (l *LogLoader) LoadLogStream(ctx context.Context, in LogInput) (*logs.TailStream, error) {
+	params, err := l.ToParam(ctx, in)
+	if err != nil {
+		return nil, fmt.Errorf("error processing arguments: %v", err)
+	}
+
+	stream, err := l.logRepo.TailLogsWithErrors(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("error tailing logs: %w", err)
+	}
+	return stream, nil
+}
+
 func (l *LogLoader) getResourceIDsFromIDOrNames(ctx context.Context, idOrNames []string) ([]string, error) {
 	resourceIds := make([]string, len(idOrNames))
 

--- a/pkg/tui/views/logloader_test.go
+++ b/pkg/tui/views/logloader_test.go
@@ -3,8 +3,13 @@ package views_test
 import (
 	"context"
 	"testing"
+	"time"
 
+	renderapi "github.com/render-oss/cli/internal/fakes/renderapi"
+	"github.com/render-oss/cli/pkg/client"
+	logclient "github.com/render-oss/cli/pkg/client/logs"
 	"github.com/render-oss/cli/pkg/config"
+	"github.com/render-oss/cli/pkg/logs"
 	"github.com/render-oss/cli/pkg/tui/views"
 	"github.com/stretchr/testify/require"
 )
@@ -53,4 +58,33 @@ func TestLogLoaderToParam(t *testing.T) {
 		require.Equal(t, "wrk-test123", params.OwnerId)
 		require.Equal(t, []string{resourceID}, params.Resource)
 	})
+}
+
+func TestLoadLogStreamUsesExistingRepositoryAndClosesOnCancel(t *testing.T) {
+	server := renderapi.NewServer(t)
+	server.Logs.QueueStream(renderapi.LogStreamAttempt{
+		Logs: []logclient.Log{{
+			Id: "log-1", Message: "hello", Timestamp: time.Unix(100, 0).UTC(),
+		}},
+		HoldOpen: true,
+	})
+	c, err := client.NewClientWithResponses(server.URL())
+	require.NoError(t, err)
+	loader := views.NewLocalLogLoader(logs.NewLogRepo(c, &config.APIConfig{Host: server.URL()}))
+	ctx, cancel := context.WithCancel(context.Background())
+
+	stream, err := loader.LoadLogStream(ctx, views.LogInput{
+		ResourceIDs: []string{"job-fake0000000000000000"},
+		Tail:        true,
+	})
+	require.NoError(t, err)
+	<-server.Logs.Opened()
+	entry := <-stream.Logs
+	require.Equal(t, "hello", entry.Message)
+	cancel()
+	<-server.Logs.Closed()
+	for range stream.Logs {
+	}
+	for range stream.Errors {
+	}
 }


### PR DESCRIPTION
## Summary

- add `--wait`, `--tail`, and `--timeout` to `jobs create`; `--tail` implies `--wait`
- poll the existing retrieve-job endpoint until a terminal status and return the final job
- reuse the existing log loader/websocket path, with bounded transient reconnect, timestamp resume, and replay deduplication
- keep structured stdout as one JSON/YAML document while progress and tailed logs use stderr

## Behavior and rationale

Interactive job creation already hands the created job to the existing log flow. Noninteractive creation instead returned immediately after its single create request, so CI could not observe the terminal state or propagate failure.

The new runner composes the existing job repository and log loader without changing generated clients. It creates exactly once and never retries that POST. Status GETs retry only explicit 429, 5xx, timeout, connection-reset/refused/aborted, and unexpected-EOF failures, with a fixed retry ceiling and ticker-driven backoff. Log reconnects are likewise limited to explicitly transient HTTP, websocket, and network failures; reconnects resume at the last timestamp and deduplicate inclusive-cursor replays.

The command contract is:

- `succeeded`: final job on stdout, exit 0
- `failed` or `canceled`: final job on stdout, exit 1
- missing or unknown status: bounded error
- JSON/YAML: progress and logs on stderr; exactly one final object on stdout
- text: progress on stderr; streamed logs and final status on stdout

Canceling, timing out, or reaching a terminal state cancels the stream context. The websocket repository closes the connection to unblock reads, and buffered log entries are drained without waiting on a stream that remains open.

## Reproducible local transcript

Captured by a temporary integration harness that executed the actual Cobra root against `internal/fakes/renderapi`; the harness parsed each JSON stdout value before reporting `parsed status` and was removed afterward.

```text
scenario: successful wait
args: jobs create srv-jobcreate000000000 --wait --start-command 'echo success' --output json
stdout:
{
  "id": "job-fake0000000000000000",
  "serviceId": "srv-jobcreate000000000",
  "startCommand": "echo success",
  "status": "succeeded"
}
stderr:
Waiting for job job-fake0000000000000000 to finish...
parsed status: succeeded
exit: 0

scenario: failed wait
args: jobs create srv-jobcreate000000000 --wait --start-command 'exit 1' --output json
stdout:
{
  "id": "job-fake0000000000000000",
  "serviceId": "srv-jobcreate000000000",
  "startCommand": "exit 1",
  "status": "failed"
}
stderr:
Waiting for job job-fake0000000000000000 to finish...
Error: job job-fake0000000000000000 finished with status failed
parsed status: failed
exit: 1

scenario: tail with structured output
args: jobs create srv-jobcreate000000000 --tail --output json
stdout:
{
  "id": "job-fake0000000000000000",
  "serviceId": "srv-jobcreate000000000",
  "status": "succeeded"
}
stderr:
Waiting for job job-fake0000000000000000 to finish...
1970-01-01 00:01:40  build complete
parsed status: succeeded
exit: 0
```

The displayed JSON is compacted to the review-relevant fields; parsing was performed on the complete emitted document.

## Validation

- focused command, runner, log repository, and log-loader tests
- Linux race detector across all four affected packages
- full `./cmd/... ./pkg/... ./internal/...` package sweep, with environment-specific filesystem/timing cases rerun successfully under native Linux filesystems
- `golangci-lint` 2.13.1 on the changed diff: `0 issues`
- repository hooks: formatting, module tidiness, shell checks, filename checks, lint, and 5 BashUnit tests / 16 assertions
- production CLI build
- `git diff --check`

Fixes #24
